### PR TITLE
Fix Renovate Config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["github>pcartwright81/renovate-default-config"]
+  "extends": ["github>pcartwright81/renovate-config"]
 }


### PR DESCRIPTION
Updates Renovate configuration to use the correct config repository.

Changes:
- Updated extends from `github>pcartwright81/renovate-default-config` to `github>pcartwright81/renovate-config`